### PR TITLE
Update to dotNet External Use, DynamicCode Example

### DIFF
--- a/2sxc Docs Generator/net-code/external/dotnet-external-use.md
+++ b/2sxc Docs Generator/net-code/external/dotnet-external-use.md
@@ -29,6 +29,40 @@ vals.Add("Label", "Test Tag");
 App.Data.Create("Tag", vals);
 ```
 
+## Example of Gaining Access to Links Managed in a simple 2sxc Content App
+ 
+Imagine you have a theme using DDR Menu with Razor Templates. The theme has a MegaMenu and you want to include one or more featured links that will change often and those links are easily managed in the Content App using the Links Content-Type with any of the default Views.
+
+Your C# code in your MegaMenu.cshtml file could get access to those Links like this:
+
+```cs
+// the details you need to know
+// var appId = 2;       // Content App is usually 2, but thanks to DynamicCode, we don't need this
+var tabId = 234;        // this is the page with the Links View on it
+var modId = 678;        // this is the module ID of the Links View
+ 
+// get the BlockBuilder
+var block = ToSic.Sxc.Dnn.Factory.CmsBlock(tabId, modId);
+ 
+// the get the DynamicCode instance (Code.DnnDynamicCodeRoot) of the block
+var dynCode = ToSic.Sxc.Dnn.Factory.DynamicCode(block);
+ 
+// if we were running "inside" 2sxc, we would just do this:
+// var links = AsList(Data["Default"]);
+// but instead we use our magical DynamicCode instance like this
+var links = dynCode.AsList(dynCode.App.Data["Default"]);
+ 
+<ul>
+foreach (var link in links) 
+{
+  <li>
+    @link.EntityTitle, <a href="@link.Link">@link.LinkText</a>
+  </li>
+}
+</ul>
+
+```
+
 ## Read also
 
 * [DNN Factory API](xref:ToSic.Sxc.Dnn.Factory)


### PR DESCRIPTION
Added a (hopefully useful and working) example based on this StackOverflow Q&A
https://stackoverflow.com/questions/67376922/how-to-access-another-modules-content-and-presentation-items-after-2sxc-v10-20